### PR TITLE
修复 vue-loader 导致本地开发预览页面问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "uslug": "^1.0.4",
     "uuid": "^7.0.3",
     "vue-component-analyzer": "^0.2.0",
+    "vue-loader": "~15.9.2",
     "vue-router": "^3.0.1",
     "vusion-api": "^0.7.36",
     "vusion-loader": "^0.5.1"


### PR DESCRIPTION
锁定 vue-loader 版本在 15.9.x

<img width="912" alt="image" src="https://user-images.githubusercontent.com/12060054/231937153-0f9461fc-931f-46a4-85c0-500c5a4a66bc.png">
