### PR TITLE
fix: 🐛 set default value for vusionConfig.docsPath

### DIFF
--- a/service/chainDoc.js
+++ b/service/chainDoc.js
@@ -98,7 +98,7 @@ module.exports = function chainDoc(api, vueConfig, vusionConfig) {
             .loader(autoLoaderPath)
             .options(vusionConfig);
 
-        const docsPath = path.resolve(process.cwd(), vusionConfig.docsPath);
+        const docsPath = path.resolve(process.cwd(), vusionConfig.docsPath || 'docs');
         const docsComponentsPath = path.resolve(docsPath, 'components');
         const docsViewsPath = path.resolve(docsPath, 'views');
         const docsImportsPath = path.resolve(docsPath, 'imports.js');


### PR DESCRIPTION
```js
const docsPath = path.resolve(process.cwd(), vusionConfig.docsPath || 'docs');
```

![image](https://user-images.githubusercontent.com/12060054/232951024-351e3c0b-1c64-47c0-a6e9-a72ccfe4a1fc.png)
